### PR TITLE
Resolve the problem of displaying the refresh layout when dragging from non-top to bottom of a target.

### DIFF
--- a/powerrefresh/src/main/java/com/lovejjfg/powerrefresh/PowerRefreshLayout.java
+++ b/powerrefresh/src/main/java/com/lovejjfg/powerrefresh/PowerRefreshLayout.java
@@ -414,7 +414,7 @@ public class PowerRefreshLayout extends ViewGroup implements NestedScrollingPare
         int pointerIndex;
 
 
-        if (!isEnabled() || isRefreshing || isLoading || !canChildScrollUp()
+        if (!isEnabled() || isRefreshing || isLoading || canChildScrollUp()
                 || mNestedScrollInProgress) {
             // Fail fast if we're not in a state where a swipe is possible
             return false;
@@ -461,7 +461,7 @@ public class PowerRefreshLayout extends ViewGroup implements NestedScrollingPare
         int pointerIndex;
 
 
-        if (!isEnabled() || !canChildScrollUp()
+        if (!isEnabled() || canChildScrollUp()
                 || isLoading || isRefreshing || mNestedScrollInProgress) {
             // Fail fast if we're not in a state where a swipe is possible
             return false;


### PR DESCRIPTION
The refresh layout occurred when dragging down from the middle of RecyclerView.
it did not happen in your example app.

It can be different situation.

The skip-condition in onInterceptTouchEvent function is different from SwipeRefreshLayout.
Why is it different?